### PR TITLE
Disallow prototype path override - checking magic attributes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -209,6 +209,23 @@ export const get = (data: any, path: DotKey, value: any | undefined = undefined,
 };
 
 
+const ILLEGAL_KEYS = new Set(["__proto__"]);
+
+const isIllegalKey = (key: string): Boolean => ILLEGAL_KEYS.has(key);
+
+const isProtoPath = (path: string[] | string): Boolean => Array.isArray(path)
+  ? path.some(isIllegalKey)
+  : typeof path === "string"
+    ? isIllegalKey(path)
+    : false;
+
+const disallowProtoPath = (path: string[] | string): void => {
+  if (isProtoPath(path)) {
+    throw new Error(`Unsafe path encountered ${path}`);
+  }
+}
+
+
 /**
  * Setter
  */
@@ -223,6 +240,7 @@ export const set = (data: any, path: DotKey, value: any): any => {
   }
 
   const tokens = tokenize(path);
+  disallowProtoPath(tokens);
 
   if (tokens.indexOf('*') < 0) {
     const res = _data;

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,13 +209,13 @@ export const get = (data: any, path: DotKey, value: any | undefined = undefined,
 };
 
 
-const ILLEGAL_KEYS = new Set(["__proto__"]);
+const ILLEGAL_KEYS = new Set(['__proto__']);
 
 const isIllegalKey = (key: string): Boolean => ILLEGAL_KEYS.has(key);
 
 const isProtoPath = (path: string[] | string): Boolean => Array.isArray(path)
   ? path.some(isIllegalKey)
-  : typeof path === "string"
+  : typeof path === 'string'
     ? isIllegalKey(path)
     : false;
 
@@ -223,7 +223,7 @@ const disallowProtoPath = (path: string[] | string): void => {
   if (isProtoPath(path)) {
     throw new Error(`Unsafe path encountered ${path}`);
   }
-}
+};
 
 
 /**

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -362,6 +362,8 @@ describe('dot-wild', () => {
       hoge: date1,
     });
     assertDate();
+
+    assert.throws(() => dot.set(t1, '__proto__.polluted', true));
   });
 
 


### PR DESCRIPTION
### 📊 Metadata *

dot-wild is vulnerable to Prototype Pollution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-dot-wild/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```javascript
// poc.js
var dot = require("dot-wild")

var obj = {};
console.log("Before: " + {}.polluted);
dot.set(obj, "__proto__.polluted", "Yes, its polluted")
console.log("After: ", {}.polluted);
```
2. Execute the following commands in the terminal:
```bash
npm i dot-wild # install vulnerable package
node poc.js # run the PoC
```
3. Check the output:
```
Before: undefined
After: Yes, its polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106396203-76d5e500-642c-11eb-852e-cdd21408412a.png)

After:
![image](https://user-images.githubusercontent.com/64132745/106396216-910fc300-642c-11eb-9463-36558fea382b.png)


### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/106396631-27dd7f00-642f-11eb-92c2-77541bce4160.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1818
